### PR TITLE
Fix to use plugin in CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/pekebyte/pekeUpload/issues"
   },
   "homepage": "https://github.com/pekebyte/pekeUpload",
+  "main": "./js/pekeUpload.min.js",
   "dependencies": {
     "jquery":">=1.4.3"
   }


### PR DESCRIPTION
Add please this line to your package.json for use plugin in CommonJS/Browserify bundles.

"main": "./js/pekeUpload.min.js",